### PR TITLE
Add ability to filter specimen records by USIs in label generator

### DIFF
--- a/src/js/labels/formData.ts
+++ b/src/js/labels/formData.ts
@@ -2,6 +2,8 @@ import { SpecimenLabel } from '../types/specimen-label';
 import { transformData } from './transformData';
 
 interface LabelForm {
+    usi_mode: 'none' | 'include' | 'exclude';
+    usi_input_text: string;
     order: string,
     family: string,
     subfamily: string,
@@ -12,7 +14,6 @@ interface LabelForm {
     determiner_firstname: string,
     determiner_lastname: string,
     determined_year: number | '',
-    usi: string,
     preparer_firstname: string,
     preparer_lastname: string,
     preparation: string,
@@ -48,6 +49,8 @@ type LabelFormKey = keyof LabelForm;
 type FilterableKey = keyof LabelForm & keyof SpecimenLabel;
 
 const emptyFormObject: LabelForm = {
+    usi_mode: 'none',
+    usi_input_text: '',
     order: '',
     family: '',
     subfamily: '',
@@ -58,7 +61,6 @@ const emptyFormObject: LabelForm = {
     determiner_firstname: '',
     determiner_lastname: '',
     determined_year: '',
-    usi: '',
     preparer_firstname: '',
     preparer_lastname: '',
     preparation: '',
@@ -93,7 +95,20 @@ const emptyFormObject: LabelForm = {
 let formData: LabelForm = { ...emptyFormObject };
 
 /**
+ * Updates the USI filter mode and list
+ * @param usiInputText - The user's input text
+ */
+export function setUsiFilter(usiInputText: string) {
+    return new Set(
+        usiInputText
+            .split(',')
+            .map((usi: string) => usi.trim()),
+    );
+}
+
+/**
  * Adds an onChange event listener to each input/select element within the label form
+ * @param elements - A Node list of input elements to watch for changes
  */
 export function addChangeEvent(
     elements: NodeListOf<HTMLInputElement> | NodeListOf<HTMLSelectElement>,
@@ -110,6 +125,11 @@ export function addChangeEvent(
 
 let submitTimeout: NodeJS.Timeout;
 
+/**
+ * Handles the submitting of the label generator form
+ * @param event - The submit event
+ * @param data - The data in the form
+ */
 export async function handleSubmit(event: SubmitEvent, data: SpecimenLabel[]) {
     event.preventDefault();
 
@@ -119,12 +139,29 @@ export async function handleSubmit(event: SubmitEvent, data: SpecimenLabel[]) {
     // submit button (puts a short delay between button clicks). When the form first submits, any
     // previous timeout is cleared above.
     submitTimeout = setTimeout(() => {
-        // Filter out the formData above to remove any keys that have empty values
-        // (as we will only filter on what the user entered). Using .reduce() to build a single
+        let workingData = data;
+
+        if (formData.usi_mode === 'include' && formData.usi_input_text.length > 0) {
+            workingData = workingData.filter((specimen) => (
+                setUsiFilter(formData.usi_input_text).has(specimen.usi)
+            ));
+        } else if (formData.usi_mode === 'exclude' && formData.usi_input_text.length > 0) {
+            workingData = workingData.filter((specimen) => (
+                !setUsiFilter(formData.usi_input_text).has(specimen.usi)
+            ));
+        }
+
+        // Filter out the formData to remove any keys that have empty values
+        // (as we will only filter on what the user entered) and exclude USI fields
+        // (USI filtering is already done above). Using .reduce() to build a single
         // object containing only keys with values
         const filteredFormData = (
             Object.keys(formData) as LabelFormKey[]
         ).reduce<Partial<LabelForm>>((r, key) => {
+            // Skip USI-related fields - they're handled separately
+            if (key === 'usi_mode' || key === 'usi_input_text') {
+                return r;
+            }
             if (formData[key]) {
                 return { ...r, [key]: formData[key] };
             }
@@ -137,9 +174,9 @@ export async function handleSubmit(event: SubmitEvent, data: SpecimenLabel[]) {
         // Else, we filter the specimens using the filteredFormData that the user has entered,
         // and we create labels for only those filtered specimens.
         if (Object.keys(filteredFormData).length === 0) {
-            transformData(data);
+            transformData(workingData);
         } else {
-            const filteredSpecimens = data.filter((specimen: SpecimenLabel) => (
+            const filteredSpecimens = workingData.filter((specimen: SpecimenLabel) => (
                 Object.entries(filteredFormData) as [
                     FilterableKey,
                     LabelForm[FilterableKey],

--- a/src/pages/labels.njk
+++ b/src/pages/labels.njk
@@ -25,6 +25,21 @@ js: [
 <form aria-labelledby="label-label" class="no-print" id="label-form">
     <span hidden id="label-label">Label Generator</span>
     <fieldset>
+        <legend>USI Filter (Optional)</legend>
+        <label for="usi-list-input">
+            List of USIs to Filter
+            <input type="tex" id="usi-list-input" name="usi_input_text"></input>
+        </label>
+        <label for="usi-mode-input">
+            USI Filter Mode
+            <select id="usi-mode-input" name="usi_mode">
+                <option>none</option>
+                <option>include</option>
+                <option>exclude</option>
+            </select>
+        </label>
+    </fieldset>
+    <fieldset>
         <legend>Taxonomy</legend>
         <label for="order-input">
             Order
@@ -69,10 +84,6 @@ js: [
     </fieldset>
     <fieldset>
         <legend>Specimen Info</legend>
-        <label for="usi-input">
-            Unique Specimen Identifier (USI)
-            <input id="usi-input" inputmode="text" name="usi" type="text"/>
-        </label>
         <label for="preparer-first-name-input">
             Preparer First Name
             <input id="preparer-first-name-input" inputmode="text" name="preparer_firstname" type="text"/>


### PR DESCRIPTION
Adds ability on the label generator form to provide a list of specimen USIs with the option to either exclude them from having labels generated or include only them when generating labels. This is to help me when I will need to redo a small subset of labels.